### PR TITLE
Updating symfony/console and adding symfony/yaml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,12 @@
         "doctrine/collections": "^1.4",
         "jms/serializer": "^1.2",
         "imagine/imagine": "~0.5.0",
-        "symfony/console": "^3.1",
+        "symfony/console": "~4.1",
         "symfony/filesystem": "^3.1",
         "monolog/monolog": "^1.22",
         "webmozart/assert": "^1.2",
         "symfony/stopwatch": "^3.1",
+        "symfony/yaml": "^4.2",
         "sixty-nine/php-data-types": "0.1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Updating symfony/console from ^3.1 to ~4.1 and adding symfony/yaml ^4.2 required to read the src/SixtyNine/Cloud/Resources/palettes.yml