### PR TITLE
Fix uasort in WordsList

### DIFF
--- a/src/SixtyNine/Cloud/Model/WordsList.php
+++ b/src/SixtyNine/Cloud/Model/WordsList.php
@@ -146,10 +146,10 @@ class WordsList
             $attr2 = $b->$method();
 
             if ($sortOrder === self::SORT_ASC) {
-                return $attr1 > $attr2;
+                return $attr1 > $attr2 ? -1 : 1;
             }
 
-            return $attr1 < $attr2;
+            return $attr1 < $attr2 ? -1 : 1;
         };
 
 


### PR DESCRIPTION
The sort function needs to return int instead ob bool.

uasort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero